### PR TITLE
feat: add optional parameter singleQuote to generate files with singl…

### DIFF
--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -16,12 +16,26 @@ export type GenTypesConfig = {
    * @default false
    */
   singleFile: boolean;
+  /**
+   * Formatting options for generated files
+   */
+  prettier?: {
+    /**
+     * Use single quotes instead of double quotes in imports
+     *
+     * @default true
+     */
+    singleQuote?: boolean;
+  };
 };
 
 export default {
   default: ({ env }) => ({
     outputLocation: env("GEN_TYPES_OUTPUT_LOCATION", "src/genTypes"),
     singleFile: env("GEN_TYPES_SINGLE_FILE", false),
+    prettier: {
+      singleQuote: env("GEN_TYPES_SINGLE_QUOTE", true),
+    },
   }),
   validator(config: GenTypesConfig) {
     if (!config.outputLocation) {

--- a/server/src/register.ts
+++ b/server/src/register.ts
@@ -3,14 +3,14 @@ import type { GenTypesConfig } from "./config";
 import { pluginName } from "./genTypes/types";
 
 const register = ({ strapi }: { strapi: Core.Strapi }) => {
-  strapi.log.info("Gen Types Plugin registered");
+  strapi.log.info("AL Gen Types Plugin registered");
   if (process.env.NODE_ENV === "production") {
-    strapi.log.info("Gen Types Plugin is disabled in production");
+    strapi.log.info("Al Gen Types Plugin is disabled in production");
   } else {
     const config: GenTypesConfig = strapi.config.get("plugin::gen-types");
     strapi
       .service(`plugin::${pluginName}.service`)
-      .generateInterfaces(config.outputLocation, config.singleFile);
+      .generateInterfaces(config.outputLocation, config.singleFile, config?.prettier?.singleQuote);
   }
 };
 

--- a/server/src/register.ts
+++ b/server/src/register.ts
@@ -10,7 +10,7 @@ const register = ({ strapi }: { strapi: Core.Strapi }) => {
     const config: GenTypesConfig = strapi.config.get("plugin::gen-types");
     strapi
       .service(`plugin::${pluginName}.service`)
-      .generateInterfaces(config.outputLocation, config.singleFile);
+      .generateInterfaces(config.outputLocation, config.singleFile, config?.prettier?.singleQuote);
   }
 };
 

--- a/server/src/register.ts
+++ b/server/src/register.ts
@@ -3,9 +3,9 @@ import type { GenTypesConfig } from "./config";
 import { pluginName } from "./genTypes/types";
 
 const register = ({ strapi }: { strapi: Core.Strapi }) => {
-  strapi.log.info("AL Gen Types Plugin registered");
+  strapi.log.info("Gen Types Plugin registered");
   if (process.env.NODE_ENV === "production") {
-    strapi.log.info("Al Gen Types Plugin is disabled in production");
+    strapi.log.info("Gen Types Plugin is disabled in production");
   } else {
     const config: GenTypesConfig = strapi.config.get("plugin::gen-types");
     strapi


### PR DESCRIPTION
This PR adds configurable quote style for generated import statements via prettier.singleQuote.

Default behavior remains unchanged
Import generation is centralized to avoid inconsistencies
Applies consistently to single-file and multi-file outputs